### PR TITLE
issue_bg1975_tranlator_api_version_up

### DIFF
--- a/lib/translator_proxy/version.rb
+++ b/lib/translator_proxy/version.rb
@@ -1,3 +1,3 @@
 module TranslatorProxy
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/translator_proxy/bing_provider_spec.rb
+++ b/spec/translator_proxy/bing_provider_spec.rb
@@ -20,7 +20,7 @@ describe TranslatorProxy::BingProvider do
   end
 
   describe '#translate_bulk' do
-    let(:texts) { %w(おはよう こんにちは こんばんは) }
+    let(:texts) { %w(おはようございます こんにちは こんばんは) }
 
     it 'should return translated texts' do
       VCR.use_cassette 'translate_bulk_response' do

--- a/spec/translator_proxy/server_spec.rb
+++ b/spec/translator_proxy/server_spec.rb
@@ -34,7 +34,7 @@ describe 'Server Service' do
   it 'should return a translated text json' do
     url = URI.encode '/bulk'
     params = {
-      texts: %w(おはよう こんにちは こんばんは),
+      texts: %w(おはようございます こんにちは こんばんは),
       from:  'ja',
       to:    'en'
     }

--- a/spec/vcr/translate_bulk_response.yml
+++ b/spec/vcr/translate_bulk_response.yml
@@ -27,7 +27,7 @@ http_interactions:
       Pragma:
       - no-cache
       Content-Length:
-      - '708'
+      - '795'
       Content-Type:
       - application/jwt; charset=us-ascii
       Expires:
@@ -37,28 +37,24 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Apim-Request-Id:
-      - 2004dc9a-e8b3-4ea4-a0f1-f86300e63e50
+      - 9ed185db-af00-4d2a-b80a-81799b2dbf20
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 01 May 2017 04:22:52 GMT
+      - Fri, 26 Apr 2019 07:15:48 GMT
     body:
       encoding: UTF-8
-      string: hoge
+      string: eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTQ5IiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.MOkXOrn6CyHswoMsY6CwHbHaVSQn-_IgamtSVQy0Ze0
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:22:53 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:49 GMT
 - request:
     method: post
-    uri: http://api.microsofttranslator.com/V2/Http.svc/TranslateArray
+    uri: https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=ja&to=en
     body:
       encoding: UTF-8
-      string: "<TranslateArrayRequest><AppId/><From>ja</From><Options><ContentType
-        xmlns='http://schemas.datacontract.org/2004/07/Microsoft.MT.Web.Service.V2'>text/html</ContentType></Options><Texts><string
-        xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>おはよう</string><string
-        xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>こんにちは</string><string
-        xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>こんばんは</string></Texts><To>en</To></TranslateArrayRequest>"
+      string: '[{"text":"おはようございます"},{"text":"こんにちは"},{"text":"こんばんは"}]'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -67,34 +63,36 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.microsofttranslator.com
+      - api.cognitive.microsofttranslator.com
       Authorization:
-      - Bearer hoge
+      - Bearer eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTQ5IiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.MOkXOrn6CyHswoMsY6CwHbHaVSQn-_IgamtSVQy0Ze0
       Content-Type:
-      - application/xml
+      - application/json
   response:
     status:
       code: 200
       message: OK
     headers:
-      Content-Length:
-      - '1383'
       Content-Type:
-      - application/xml; charset=utf-8
-      X-Ms-Trans-Info:
-      - 1146.V2_Rest.TranslateArray.4CE12424
+      - application/json; charset=utf-8
+      X-Mt-System:
+      - Microsoft
+      X-Requestid:
+      - TRAN.3597.146EADC5
+      Access-Control-Expose-Headers:
+      - X-RequestId
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 01 May 2017 04:22:53 GMT
+      - Fri, 26 Apr 2019 07:15:49 GMT
+      Content-Length:
+      - '153'
     body:
       encoding: UTF-8
-      string: <ArrayOfTranslateArrayResponse xmlns="http://schemas.datacontract.org/2004/07/Microsoft.MT.Web.Service.V2"
-        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><TranslateArrayResponse><From>ja</From><OriginalTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>4</a:int></OriginalTextSentenceLengths><TranslatedText>Good
-        morning</TranslatedText><TranslatedTextSentenceLengths xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>12</a:int></TranslatedTextSentenceLengths></TranslateArrayResponse><TranslateArrayResponse><From>ja</From><OriginalTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>5</a:int></OriginalTextSentenceLengths><TranslatedText>Hello</TranslatedText><TranslatedTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>5</a:int></TranslatedTextSentenceLengths></TranslateArrayResponse><TranslateArrayResponse><From>ja</From><OriginalTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>5</a:int></OriginalTextSentenceLengths><TranslatedText>Good
-        evening</TranslatedText><TranslatedTextSentenceLengths xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>12</a:int></TranslatedTextSentenceLengths></TranslateArrayResponse></ArrayOfTranslateArrayResponse>
+      string: '[{"translations":[{"text":"Good morning","to":"en"}]},{"translations":[{"text":"Hello","to":"en"}]},{"translations":[{"text":"Good
+        evening","to":"en"}]}]'
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:22:53 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr/translate_bulk_server_response.yml
+++ b/spec/vcr/translate_bulk_server_response.yml
@@ -27,7 +27,7 @@ http_interactions:
       Pragma:
       - no-cache
       Content-Length:
-      - '708'
+      - '795'
       Content-Type:
       - application/jwt; charset=us-ascii
       Expires:
@@ -37,28 +37,24 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Apim-Request-Id:
-      - 29f86a55-7998-4e07-8e52-2c35ef15fe3e
+      - 8b63a241-b509-4eac-8032-bb958b6f5865
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 01 May 2017 04:34:05 GMT
+      - Fri, 26 Apr 2019 07:15:49 GMT
     body:
       encoding: UTF-8
-      string: hoge
+      string: eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTUwIiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.7ZMyqpkQRdt6S8amlzYNLzDJEv3wlsywGuiQrT38UqE
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:34:06 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:50 GMT
 - request:
     method: post
-    uri: http://api.microsofttranslator.com/V2/Http.svc/TranslateArray
+    uri: https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=ja&to=en
     body:
       encoding: UTF-8
-      string: "<TranslateArrayRequest><AppId/><From>ja</From><Options><ContentType
-        xmlns='http://schemas.datacontract.org/2004/07/Microsoft.MT.Web.Service.V2'>text/html</ContentType></Options><Texts><string
-        xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>おはよう</string><string
-        xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>こんにちは</string><string
-        xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>こんばんは</string></Texts><To>en</To></TranslateArrayRequest>"
+      string: '[{"text":"おはようございます"},{"text":"こんにちは"},{"text":"こんばんは"}]'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -67,34 +63,38 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.microsofttranslator.com
+      - api.cognitive.microsofttranslator.com
       Authorization:
-      - Bearer hoge
+      - Bearer eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTUwIiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.7ZMyqpkQRdt6S8amlzYNLzDJEv3wlsywGuiQrT38UqE
       Content-Type:
-      - application/xml
+      - application/json
   response:
     status:
       code: 200
       message: OK
     headers:
-      Content-Length:
-      - '1383'
       Content-Type:
-      - application/xml; charset=utf-8
-      X-Ms-Trans-Info:
-      - 1250.V2_Rest.TranslateArray.4CD1D2E2
+      - application/json; charset=utf-8
+      X-Mt-System:
+      - Microsoft
+      X-Requestid:
+      - TRAN.A7B9.B5299100
+      Access-Control-Expose-Headers:
+      - X-RequestId
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ARR/3.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 01 May 2017 04:34:05 GMT
+      - Fri, 26 Apr 2019 07:15:50 GMT
+      Content-Length:
+      - '153'
     body:
       encoding: UTF-8
-      string: <ArrayOfTranslateArrayResponse xmlns="http://schemas.datacontract.org/2004/07/Microsoft.MT.Web.Service.V2"
-        xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><TranslateArrayResponse><From>ja</From><OriginalTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>4</a:int></OriginalTextSentenceLengths><TranslatedText>Good
-        morning</TranslatedText><TranslatedTextSentenceLengths xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>12</a:int></TranslatedTextSentenceLengths></TranslateArrayResponse><TranslateArrayResponse><From>ja</From><OriginalTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>5</a:int></OriginalTextSentenceLengths><TranslatedText>Hello</TranslatedText><TranslatedTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>5</a:int></TranslatedTextSentenceLengths></TranslateArrayResponse><TranslateArrayResponse><From>ja</From><OriginalTextSentenceLengths
-        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>5</a:int></OriginalTextSentenceLengths><TranslatedText>Good
-        evening</TranslatedText><TranslatedTextSentenceLengths xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:int>12</a:int></TranslatedTextSentenceLengths></TranslateArrayResponse></ArrayOfTranslateArrayResponse>
+      string: '[{"translations":[{"text":"Good morning","to":"en"}]},{"translations":[{"text":"Hello","to":"en"}]},{"translations":[{"text":"Good
+        evening","to":"en"}]}]'
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:34:06 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr/translate_response.yml
+++ b/spec/vcr/translate_response.yml
@@ -27,7 +27,7 @@ http_interactions:
       Pragma:
       - no-cache
       Content-Length:
-      - '708'
+      - '795'
       Content-Type:
       - application/jwt; charset=us-ascii
       Expires:
@@ -37,24 +37,24 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Apim-Request-Id:
-      - 425bac90-d4d8-4228-a5e5-bd1d891c40ae
+      - 8a2063ac-5aa5-4217-b91e-61efe9d17896
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 01 May 2017 04:22:50 GMT
+      - Fri, 26 Apr 2019 07:15:47 GMT
     body:
       encoding: UTF-8
-      string: hoge
+      string: eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTQ4IiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.70DJrU452c8w76X4I6EE0saNolBCBsVafpl3eTo9d5E
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:22:52 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:48 GMT
 - request:
-    method: get
-    uri: http://api.microsofttranslator.com/v2/HTTP.svc/Translate?from=ja&text=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF&to=en
+    method: post
+    uri: https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=ja&to=en
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '[{"text":"こんにちは"}]'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -63,27 +63,37 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.microsofttranslator.com
+      - api.cognitive.microsofttranslator.com
       Authorization:
-      - Bearer hoge
+      - Bearer eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTQ4IiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.70DJrU452c8w76X4I6EE0saNolBCBsVafpl3eTo9d5E
       Content-Type:
-      - application/xml
+      - application/json
   response:
     status:
       code: 200
       message: OK
     headers:
-      Content-Length:
-      - '82'
       Content-Type:
-      - application/xml; charset=utf-8
-      X-Ms-Trans-Info:
-      - 1146.V2_Rest.Translate.4CE123D9
+      - application/json; charset=utf-8
+      X-Mt-System:
+      - Microsoft
+      X-Requestid:
+      - TRAN.A7B9.01624FAD
+      Access-Control-Expose-Headers:
+      - X-RequestId
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ARR/3.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 01 May 2017 04:22:52 GMT
+      - Fri, 26 Apr 2019 07:15:48 GMT
+      Content-Length:
+      - '47'
     body:
       encoding: UTF-8
-      string: <string xmlns="http://schemas.microsoft.com/2003/10/Serialization/">Hello</string>
+      string: '[{"translations":[{"text":"Hello","to":"en"}]}]'
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:22:53 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr/translate_server_response.yml
+++ b/spec/vcr/translate_server_response.yml
@@ -27,7 +27,7 @@ http_interactions:
       Pragma:
       - no-cache
       Content-Length:
-      - '708'
+      - '795'
       Content-Type:
       - application/jwt; charset=us-ascii
       Expires:
@@ -37,24 +37,24 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Apim-Request-Id:
-      - 05d2df2a-05a7-4b35-99ee-d961796cfd08
+      - 24d4d765-d75e-42da-9232-8cf126b5fc9b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 01 May 2017 04:34:07 GMT
+      - Fri, 26 Apr 2019 07:15:49 GMT
     body:
       encoding: UTF-8
-      string: hoge
+      string: eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTQ5IiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.MOkXOrn6CyHswoMsY6CwHbHaVSQn-_IgamtSVQy0Ze0
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:34:06 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:49 GMT
 - request:
-    method: get
-    uri: http://api.microsofttranslator.com/v2/HTTP.svc/Translate?from=ja&text=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF&to=en
+    method: post
+    uri: https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=ja&to=en
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '[{"text":"こんにちは"}]'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -63,27 +63,35 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.microsofttranslator.com
+      - api.cognitive.microsofttranslator.com
       Authorization:
-      - Bearer hoge
+      - Bearer eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ1cm46bXMuY29nbml0aXZlc2VydmljZXMiLCJleHAiOiIxNTU2MjYzNTQ5IiwicmVnaW9uIjoiZ2xvYmFsIiwic3Vic2NyaXB0aW9uLWlkIjoiNGIzMzljN2JhYmE4NDhmNTlkNTM0ODY5M2QzMjBiNDQiLCJwcm9kdWN0LWlkIjoiVGV4dFRyYW5zbGF0b3IuUzEiLCJjb2duaXRpdmUtc2VydmljZXMtZW5kcG9pbnQiOiJodHRwczovL2FwaS5jb2duaXRpdmUubWljcm9zb2Z0LmNvbS9pbnRlcm5hbC92MS4wLyIsImF6dXJlLXJlc291cmNlLWlkIjoiL3N1YnNjcmlwdGlvbnMvMDE0OWU1NzUtZGZiMC00N2QzLWJhY2MtNmU1MDA1ZjBjMTUwL3Jlc291cmNlR3JvdXBzL2J1eW1hLWdsb2JhbC1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNvZ25pdGl2ZVNlcnZpY2VzL2FjY291bnRzL2J1eW1hLWdsb2JhbCIsInNjb3BlIjoiaHR0cHM6Ly9hcGkubWljcm9zb2Z0dHJhbnNsYXRvci5jb20vIiwiYXVkIjoidXJuOm1zLm1pY3Jvc29mdHRyYW5zbGF0b3IifQ.MOkXOrn6CyHswoMsY6CwHbHaVSQn-_IgamtSVQy0Ze0
       Content-Type:
-      - application/xml
+      - application/json
   response:
     status:
       code: 200
       message: OK
     headers:
-      Content-Length:
-      - '82'
       Content-Type:
-      - application/xml; charset=utf-8
-      X-Ms-Trans-Info:
-      - 0151.V2_Rest.Translate.4D4D6876
+      - application/json; charset=utf-8
+      X-Mt-System:
+      - Microsoft
+      X-Requestid:
+      - TRAN.3597.BCB15383
+      Access-Control-Expose-Headers:
+      - X-RequestId
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       Date:
-      - Mon, 01 May 2017 04:34:05 GMT
+      - Fri, 26 Apr 2019 07:15:49 GMT
+      Content-Length:
+      - '47'
     body:
       encoding: UTF-8
-      string: <string xmlns="http://schemas.microsoft.com/2003/10/Serialization/">Hello</string>
+      string: '[{"translations":[{"text":"Hello","to":"en"}]}]'
     http_version: 
-  recorded_at: Mon, 01 May 2017 04:34:06 GMT
+  recorded_at: Fri, 26 Apr 2019 07:15:50 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION


<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->
[[BG-1975] Translator Text API のバージョン 3に移行 JIRA](https://enigmo.atlassian.net/browse/BG-1975)

## Related Tickets & Documents

## Description
2019年4月30日 より前に Translator Text API のバージョン 3 に移行してください
このメールは、現在 Cognitive Services Translator Text API にご登録いただいているお客様にお送りしています。

昨年 4 月、Cognitive Services の Translator Text API および Translator Hub のバージョン 2 の提供終了を発表しました。本メールは、2019年4月30日 にその両方の提供が終了し、利用できなくなることをあらためてお知らせするものです。

Translator Text のバージョン 2 がバージョン 3 に置き換えられます。新しい機能では、ニューラル機械翻訳技術 (使用可能な言語で) が利用でき、GDPR 処理者、ISO、SOC、HIPAA に準拠します。Translator Text のバージョン 2 からバージョン 3 への移行には、コードの変更が必要です。

新しいカスタム トランスレーターによって Translator Hub が置き換えられます。

必要な対応
2019年4月30日 より前に Translator Text のバージョン 3 に移行してください。Translator Text のサブスクリプション キーは、引き続き同じものを使用できます。

Translator Text のバージョン 2 で Speak() メソッドを使用している場合: Cognitive Services Speech Servicesによって Text to Speech 機能が提供されるようになりました。Text to Speech 機能を利用するには、新しい Speech Service にご登録いただく必要があります。

Translator Hub を使用して翻訳をカスタマイズしている場合: プロジェクトをカスタム トランスレーターに移行してください。カスタム トランスレーターでは、より流暢な結果が得られるよう、ニューラル翻訳技術を利用します。そのためには、Translator Text API バージョン 3 を使用する必要があります。
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?
  - [ ] readme
  - [ ] erd
  - [x] no documentation needed


[BG-1975]: https://enigmo.atlassian.net/browse/BG-1975